### PR TITLE
Update tk_cupertino_localizations.dart

### DIFF
--- a/lib/src/tk_cupertino_localizations.dart
+++ b/lib/src/tk_cupertino_localizations.dart
@@ -38,7 +38,7 @@ class _TkCupertinoLocalization
         singleDigitHourFormat: intl.DateFormat('HH', localeName),
         singleDigitMinuteFormat: intl.DateFormat('m', localeName),
         singleDigitSecondFormat: intl.DateFormat('s', localeName),
-        weekdayFormat: intl.DateFormat('EEE', localeName),
+        //weekdayFormat: intl.DateFormat('EEE', localeName),
       ),
     );
   }
@@ -55,7 +55,7 @@ class TkCupertinoLocalization extends GlobalCupertinoLocalizations {
     required super.doubleDigitMinuteFormat,
     required super.singleDigitSecondFormat,
     required super.decimalFormat,
-    required super.weekdayFormat,
+    //required super.weekdayFormat,
   });
 
   static const LocalizationsDelegate<CupertinoLocalizations> delegate =


### PR DESCRIPTION
Не дебажаться в иос, ругается на 41 и 58 строку. Посмотрел соседние локали в файле generated_cupertino_localizations.dart, там эти строки отсутствовали