### PR TITLE
Feature/add expansion tile hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,7 @@
 
 * Add contributing guide
 * Add missing changelog for version 0.0.12
+
+## 0.0.14
+
+* Added translations for CupertinoExpansionTile semantic hints.

--- a/lib/src/tk_cupertino_localizations.dart
+++ b/lib/src/tk_cupertino_localizations.dart
@@ -6,17 +6,14 @@ import 'package:intl/date_symbols.dart' as intl;
 import 'package:intl/date_symbol_data_custom.dart' as date_symbol_data_custom;
 import 'tk_patterns.dart';
 
-class _TkCupertinoLocalization
-    extends LocalizationsDelegate<CupertinoLocalizations> {
+class _TkCupertinoLocalization extends LocalizationsDelegate<CupertinoLocalizations> {
   const _TkCupertinoLocalization();
 
   @override
   bool isSupported(Locale locale) => locale.languageCode == "tk";
 
   @override
-  bool shouldReload(
-          covariant LocalizationsDelegate<CupertinoLocalizations> old) =>
-      false;
+  bool shouldReload(covariant LocalizationsDelegate<CupertinoLocalizations> old) => false;
 
   @override
   Future<CupertinoLocalizations> load(Locale locale) async {
@@ -58,8 +55,7 @@ class TkCupertinoLocalization extends GlobalCupertinoLocalizations {
     required super.weekdayFormat,
   });
 
-  static const LocalizationsDelegate<CupertinoLocalizations> delegate =
-      _TkCupertinoLocalization();
+  static const LocalizationsDelegate<CupertinoLocalizations> delegate = _TkCupertinoLocalization();
 
   @override
   String get alertDialogLabel => r'Bildiriş';
@@ -213,4 +209,22 @@ class TkCupertinoLocalization extends GlobalCupertinoLocalizations {
 
   @override
   String get cancelButtonLabel => 'Goý bolsun';
+
+  @override
+  String get expansionTileExpandedHint => 'ýygnamak üçin iki gezek basyň';
+
+  @override
+  String get expansionTileCollapsedHint => 'giňeltmek üçin iki gezek basyň';
+
+  @override
+  String get expansionTileExpandedTapHint => 'Ýygnamak';
+
+  @override
+  String get expansionTileCollapsedTapHint => 'Has giňişleýin görmek üçin giňeltmek';
+
+  @override
+  String get expandedHint => 'Ýygnalan';
+
+  @override
+  String get collapsedHint => 'Giňeldilen';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: turkmen_localization_support
 description: Provides an unofficial localization for the Turkmen language for the Turkmenistan region. Here it is possible to use the Turkmen language without adding additional classes.
-version: 0.0.13
+version: 0.0.14
 repository: https://github.com/honor864510/turkmen_localization_support
 
 environment:


### PR DESCRIPTION
Added translations for:
expandedHint
collapsedHint
expansionTileExpandedHint
expansionTileCollapsedHint
expansionTileExpandedTapHint
expansionTileCollapsedTapHint

flutter doctor -v
[✓] Flutter (Channel stable, 3.38.1, on macOS 26.0 25A354 darwin-arm64, locale en-US) [194ms]
    • Flutter version 3.38.1 on channel stable at /Users/developer/fvm/versions/3.38.1
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision b45fa18946 (5 days ago), 2025-11-12 22:09:06 -0600
    • Engine revision b5990e5ccc
    • Dart version 3.10.0
    • DevTools version 2.51.1
    • Feature flags: enable-web, enable-linux-desktop, enable-macos-desktop,
      enable-windows-desktop, enable-android, enable-ios, cli-animations, enable-native-assets,
      omit-legacy-version-file, enable-lldb-debugging

[✓] Android toolchain - develop for Android devices (Android SDK version 36.0.0) [808ms]
    • Android SDK at /Users/developer/Library/Android/sdk
    • Emulator version 35.6.11.0 (build_id 13610412) (CL:N/A)
    • Platform android-36, build-tools 36.0.0
    • Java binary at: /Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/java
      This is the JDK bundled with the latest Android Studio installation on this machine.
      To manually set the JDK path, use: `flutter config --jdk-dir="path/to/jdk"`.
    • Java version OpenJDK Runtime Environment (build 21.0.6+-13391695-b895.109)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS (Xcode 26.0) [484ms]
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Build 17A324
    • CocoaPods version 1.16.2

[✓] Chrome - develop for the web [4ms]
    • Chrome at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

[✓] Connected device (4 available) [5.7s]
    • sdk gphone64 arm64 (mobile) • emulator-5554                        • android-arm64  •
      Android 16 (API 36) (emulator)
    • iPhone 17 Pro Max (mobile)  • 452787A1-D555-41F9-B9C8-9473C0540422 • ios            •
      com.apple.CoreSimulator.SimRuntime.iOS-26-0 (simulator)
    • macOS (desktop)             • macos                                • darwin-arm64   • macOS
      26.0 25A354 darwin-arm64
    • Chrome (web)                • chrome                               • web-javascript • Google
      Chrome 142.0.7444.162

[✓] Network resources [461ms]
    • All expected network resources are available.

• No issues found!